### PR TITLE
Main

### DIFF
--- a/classes/SimpleERP.php
+++ b/classes/SimpleERP.php
@@ -205,8 +205,8 @@ class SimpleERP extends System
     }
 
 
-    /**
-     * Show messages for products with 'no quantity available' if 'suppress on zero' and yet published 
+     /**
+     * Show messages  
      *
      * @return string
      */
@@ -217,8 +217,24 @@ class SimpleERP extends System
 
         $aMessages = [];
 
+        // Show messages for products with 'no quantity available' if 'suppress on zero' and yet published 
         $oProducts = null;
         $oProducts = Product::findBy(['simple_erp_disable_on_zero=?', 'tl_iso_product.published=?', 'tl_iso_product.simple_erp_count=?'], [1, 1, '0']);
+
+        if ($oProducts) {
+
+            while ($oProducts->next()) {
+
+                $aMessages[] = '<p class="tl_error">' . sprintf(
+                    $GLOBALS['TL_LANG']['MSC']['simpleErpProductOutOfStock'],
+                    $oProducts->name
+                ) . '</p>';
+            }
+        }
+
+        // Show messages for products with cssID = 'reserved' or 'outOfStock' and yet simple_erp_count > 0 
+        $oProducts = null;
+        $oProducts = Product::findBy(['tl_iso_product.simple_erp_count>?'], [0]);
 
         if ($oProducts) {
 

--- a/classes/SimpleERP.php
+++ b/classes/SimpleERP.php
@@ -24,7 +24,25 @@ use Isotope\Model\ProductCollection;
 use Isotope\Model\ProductCollection\Order;
 
 
-class SimpleERP extends System {
+class SimpleERP extends System
+{
+
+    /** 
+     * Concatenates a class $sCssClass to previously existing classes
+     * 
+     * css classes are kept in the second entry of a serialized field
+     *
+     * @return none
+     */
+
+    private function setCssID(string &$serCssID, string $sCssClass)
+    {
+        $aCssID = unserialize($serCssID);
+        if (!$aCssID or !in_array($sCssClass, $aCssID)) {
+            $aCssID[1] .= ' ' . $sCssClass;
+        }
+        $serCssID = serialize($aCssID);
+    }
 
 
     /**
@@ -34,32 +52,50 @@ class SimpleERP extends System {
      *
      * @return none
      */
-    public function updateProductCount( IsotopeProductCollection $objOrder ) {
-
-        if( empty($objOrder->id) )
+    public function updateProductCount(IsotopeProductCollection $objOrder)
+    {
+        if (empty($objOrder->id))
             return false;
 
-        foreach( $objOrder->getItems() as $objItem ) {
+        foreach ($objOrder->getItems() as $objItem) {
 
             $objProduct = NULL;
             $objProduct = $objItem->getProduct(true);
 
-            if( !empty($objProduct->simple_erp_count) && $objProduct->simple_erp_count > 0 ) {
+            if (!empty($objProduct->simple_erp_count) && $objProduct->simple_erp_count > 0) {
 
                 // decrease available quantity
                 $objProduct->simple_erp_count = $objProduct->simple_erp_count - $objItem->quantity;
 
-                // set product suppressed if there is no quantity left and the option is checked
-                if( $objProduct->simple_erp_disable_on_zero && $objProduct->simple_erp_count <= 0 ) {
+                // set product suppressed and css class and quantity zero if there is no quantity left and the option is checked
+                if ($objProduct->simple_erp_disable_on_zero && $objProduct->simple_erp_count <= 0) {
 
                     $objProduct->simple_erp_count = 0;
                     $objProduct->published = '';
-                    
-                    \Database::getInstance()->prepare("UPDATE ".Product::getTable()." SET simple_erp_count = ?, published = ? WHERE id = ?")->execute( $objProduct->simple_erp_count, $objProduct->published, $objProduct->id );
 
-                } else {
+                    //concatenate class "outOfStock" to previously existing css-classes
+                    $serCssID = $objProduct->cssID;
+                    $this->setCssID($serCssID, 'outOfStock');
 
-                    \Database::getInstance()->prepare("UPDATE ".Product::getTable()." SET simple_erp_count = ? WHERE id = ?")->execute( $objProduct->simple_erp_count, $objProduct->id );
+                    \Database::getInstance()->prepare("UPDATE " . Product::getTable() . " SET simple_erp_count = ?, published = ?,  cssID = ?  WHERE id = ?")->execute($objProduct->simple_erp_count, $objProduct->published, $serCssID, $objProduct->id);
+                }
+
+                // set css class and quantity zero if there is no quantity left
+                elseif ($objProduct->simple_erp_count <= 0) {
+
+                    $objProduct->simple_erp_count = 0;
+
+                    //concatenate class "outOfStock" to previously existing css-classes
+                    $serCssID = $objProduct->cssID;
+                    $this->setCssID($serCssID, 'outOfStock');
+
+                    \Database::getInstance()->prepare("UPDATE " . Product::getTable() . " SET simple_erp_count = ?,   cssID = ?  WHERE id = ?")->execute($objProduct->simple_erp_count, $serCssID, $objProduct->id);
+                }
+
+                // just set new quantity in any other case
+                else {
+
+                    \Database::getInstance()->prepare("UPDATE " . Product::getTable() . " SET simple_erp_count = ? WHERE id = ?")->execute($objProduct->simple_erp_count, $objProduct->id);
                 }
             }
         }
@@ -67,44 +103,70 @@ class SimpleERP extends System {
 
 
     /**
-     * Checks if the given quantity exceeds our stock when adding product to cart
+     * Checks if the requested quantity exceeds our stock when adding product to cart.
+     * Reduce requested quantity if neccessary; set css class "reserved" if applicable
      *
      * @param Isotope\Model\Product $objProduct
      * @param Isotope\Model\ProductCollection $objCollection
      *
      * @return boolean
      */
-    public function checkQtyForCollection( Product $objProduct, $intQuantity, IsotopeProductCollection $objCollection ) {
+    public function checkQtyForCollection(Product $objProduct, $intQuantity, IsotopeProductCollection $objCollection)
+    {
 
-        if( $objProduct->simple_erp_count === '' || $objProduct->simple_erp_count === null ) {
+        if ($objProduct->simple_erp_count === '' || $objProduct->simple_erp_count === null) {
             return $intQuantity;
         }
 
-        if( $objProduct->simple_erp_count > 0 ) {
+        if ($objProduct->simple_erp_count > 0) {
 
-            // find product in cart to check if the total quantity exceeds our stock
+            // find product in cart 
             $oInCart = null;
             $oInCart = $objCollection->getItemForProduct($objProduct);
+            $qtyInCart = $oInCart->quantity ?? 0;   //quantity already in cart
 
-            if( $oInCart && ($oInCart->quantity+$intQuantity) >= $objProduct->simple_erp_count ) {
+            // remaining quantity to be requested
+            $qtyAddToCart = $objProduct->simple_erp_count - $qtyInCart;
+            $qtyAddToCart = $qtyAddToCart < 0 ? 0 : $qtyAddToCart;  // min. zero
 
-                $qtyAddToCart = $objProduct->simple_erp_count-$oInCart->quantity;
-                $qtyAddToCart = $qtyAddToCart<0?0:$qtyAddToCart;
+            // remaining quantity <= newly requested quantity: set css-class "reserved"
+            if ($qtyAddToCart <= $intQuantity) {
 
-                if( !$qtyAddToCart ) {
+                // concatenate new class "reserved" to previously existing classes
+                $serCssID = $objProduct->cssID;
+                $this->setCssID($serCssID, 'reserved');
+                \Database::getInstance()->prepare("UPDATE " . Product::getTable() . " SET  cssID = ?  WHERE id = ?")->execute($serCssID, $objProduct->id);
+
+                // remaining quantity < demanded quantity: message warns about the decrease in order
+                if ($qtyAddToCart < $intQuantity) {
+
                     Message::addError(sprintf(
-                        $GLOBALS['TL_LANG']['ERR']['simpleErpQuantityNotAvailable']
-                    ,   $objProduct->getName()
-                    ,   $objProduct->simple_erp_count
+                        $GLOBALS['TL_LANG']['ERR']['simpleErpQuantityNotAvailable'],
+                        $objProduct->getName(),
+                        $objProduct->simple_erp_count
                     ));
                 }
 
-                return $qtyAddToCart;
+                return $qtyAddToCart; // full or reduced request into cart
+            }
 
-            } else {
-                return $intQuantity;
+            // more quantity remaining than requested
+            else {
+                return $intQuantity; // full request into cart
             }
         }
+
+        // Product out of stock
+
+        // concatenate new class "outOfStock" to previously existing classes
+        $serCssID = $objProduct->cssID;
+        $this->setCssID($serCssID, 'outOfStock');
+        \Database::getInstance()->prepare("UPDATE " . Product::getTable() . " SET  cssID = ?  WHERE id = ?")->execute($serCssID, $objProduct->id);
+
+        Message::addError(sprintf(
+            $GLOBALS['TL_LANG']['MSC']['simpleErpProductOutOfStock'],
+            $objProduct->getName()
+        ));
 
         return false;
     }
@@ -119,21 +181,22 @@ class SimpleERP extends System {
      *
      * @return array
      */
-    public function updateQtyInCollection($objItem, $arrSet, $objCart) {
+    public function updateQtyInCollection($objItem, $arrSet, $objCart)
+    {
 
         $objProduct = null;
         $objProduct = $objItem->getProduct();
 
-        if( $objProduct->simple_erp_count > 0 ) {
+        if ($objProduct->simple_erp_count > 0) {
 
-            if( array_key_exists('quantity', $arrSet) && $arrSet['quantity'] && $arrSet['quantity'] > $objProduct->simple_erp_count ) {
+            if (array_key_exists('quantity', $arrSet) && $arrSet['quantity'] && $arrSet['quantity'] > $objProduct->simple_erp_count) {
 
                 $arrSet['quantity'] = $objProduct->simple_erp_count;
 
                 Message::addError(sprintf(
-                    $GLOBALS['TL_LANG']['ERR']['simpleErpQuantityNotAvailable']
-                ,   $objProduct->getName()
-                ,   $objProduct->simple_erp_count
+                    $GLOBALS['TL_LANG']['ERR']['simpleErpQuantityNotAvailable'],
+                    $objProduct->getName(),
+                    $objProduct->simple_erp_count
                 ));
             }
         }
@@ -143,30 +206,31 @@ class SimpleERP extends System {
 
 
     /**
-     * Show messages for new order status
+     * Show messages for products with 'no quantity available' if 'suppress on zero' and yet published 
      *
      * @return string
      */
-    public function getSystemMessages() {
+    public function getSystemMessages()
+    {
 
         $this->import('Database');
 
         $aMessages = [];
 
         $oProducts = null;
-        $oProducts = Product::findBy(['tl_iso_product.published=?','tl_iso_product.simple_erp_count=?'],[1,'0']);
+        $oProducts = Product::findBy(['simple_erp_disable_on_zero=?', 'tl_iso_product.published=?', 'tl_iso_product.simple_erp_count=?'], [1, 1, '0']);
 
-        if( $oProducts ) {
+        if ($oProducts) {
 
-            while( $oProducts->next() ) {
+            while ($oProducts->next()) {
 
                 $aMessages[] = '<p class="tl_error">' . sprintf(
-                    $GLOBALS['TL_LANG']['MSC']['simpleErpProductOutOfStock']
-                ,   $oProducts->name
+                    $GLOBALS['TL_LANG']['MSC']['simpleErpProductOutOfStock'],
+                    $oProducts->name
                 ) . '</p>';
             }
         }
 
-        return implode('',$aMessages);
+        return implode('', $aMessages);
     }
 }

--- a/dca/tl_iso_product.php
+++ b/dca/tl_iso_product.php
@@ -24,7 +24,7 @@ $GLOBALS['TL_DCA']['tl_iso_product']['fields']['simple_erp_count'] = array(
     'inputType'     => 'text',
     'eval'          => ['mandatory' => false, 'tl_class' => 'w50'],
     'attributes'    => ['legend' => 'general_legend', 'multilingual' => false, 'fe_sorting' => true],
-    'sql'           => "varchar(255) NOT NULL default 0",
+    'sql'           => "varchar(255) NOT NULL default ''",
 );
 
 $GLOBALS['TL_DCA']['tl_iso_product']['fields']['simple_erp_disable_on_zero'] = array(
@@ -37,6 +37,5 @@ $GLOBALS['TL_DCA']['tl_iso_product']['fields']['simple_erp_disable_on_zero'] = a
     'sql'           => "char(1) NOT NULL default ''",
 );
 
-$GLOBALS['TL_DCA']['tl_iso_product']['fields']['cssID']['exclude'] = true;
 $GLOBALS['TL_DCA']['tl_iso_product']['fields']['cssID']['filter'] = true;
 $GLOBALS['TL_DCA']['tl_iso_product']['fields']['cssID']['search'] = true;

--- a/dca/tl_iso_product.php
+++ b/dca/tl_iso_product.php
@@ -22,9 +22,9 @@ $GLOBALS['TL_DCA']['tl_iso_product']['fields']['simple_erp_count'] = array(
     'filter'        => true,
     'sorting'       => true,
     'inputType'     => 'text',
-    'eval'          => [ 'mandatory'=>false, 'tl_class'=>'w50' ],
-    'attributes'    => [ 'legend'=>'general_legend', 'multilingual'=>false, 'fe_sorting'=>true ],
-    'sql'           => "varchar(255) NOT NULL default ''",
+    'eval'          => ['mandatory' => false, 'tl_class' => 'w50'],
+    'attributes'    => ['legend' => 'general_legend', 'multilingual' => false, 'fe_sorting' => true],
+    'sql'           => "varchar(255) NOT NULL default 0",
 );
 
 $GLOBALS['TL_DCA']['tl_iso_product']['fields']['simple_erp_disable_on_zero'] = array(
@@ -32,7 +32,11 @@ $GLOBALS['TL_DCA']['tl_iso_product']['fields']['simple_erp_disable_on_zero'] = a
     'exclude'       => true,
     'filter'        => true,
     'inputType'     => 'checkbox',
-    'eval'          => [ 'tl_class'=>'w50' ],
-    'attributes'    => [ 'legend'=>'general_legend' ],
+    'eval'          => ['tl_class' => 'w50'],
+    'attributes'    => ['legend' => 'general_legend'],
     'sql'           => "char(1) NOT NULL default ''",
 );
+
+$GLOBALS['TL_DCA']['tl_iso_product']['fields']['cssID']['exclude'] = true;
+$GLOBALS['TL_DCA']['tl_iso_product']['fields']['cssID']['filter'] = true;
+$GLOBALS['TL_DCA']['tl_iso_product']['fields']['cssID']['search'] = true;


### PR DESCRIPTION
Alternative (to using the disable_on_zero option) way to handle out of stock products. If products out of stock shall not be presented for sale but still be available in a gallery, these products now can be changed by the given css-classes (f.i. not show cart button if product is reserved or out of stock).

1. usecase 'put product into cart': 

- productive version:

if product already in cart:
the remaining available quantity will be checked. If smaller than requested the requested quantity will be accordingly reduced, if zero no more items will go into cart. In the first cases  the user is informed by a message.  

- new version:
no matter if product already in cart or not:
additionally the css class "reserved" will be set if the remaining available quantity is zero.
additionally the css class "outOfStock" will be set if the initially available quantity is zero and no items will go into the cart . Message is shown.

2. usecase 'products have been ordered': 

- productive version:

available quantity of product will be adjusted.
if option disable_on_zero is set and no quantity is left, the product will be dis-published.  

- new version:
additionally the css-class "outOfStock" will be set if no quantity is left.

4. systemMessages now only appear if disable_on_zero option is checked.

6. Thinking about more systemMessages showing up if css class "reserved" and not "outOfStock". This should be the case when items in cart but not ordered. How to set a suitable timeperiod for the time between?



Sorry for the many diffs in compare resulting from formatter in IDE.
Thanks a lot, hope, my PR will be useful.